### PR TITLE
fixed bug with exit splash screen on headless start mode + updated to work with virtualbox 7.0+

### DIFF
--- a/data/language/english.ini
+++ b/data/language/english.ini
@@ -18,7 +18,7 @@
 04="Saved"
 05="Restart Portable-VirtualBox for the updated settings to take effect."
 06="Starting Portable-VirtualBox"
-07="Exititing Portable-VirtualBox"
+07="Exiting Portable-VirtualBox"
 
 ; error-messages on start
 

--- a/data/settings/vboxinstall.ini
+++ b/data/settings/vboxinstall.ini
@@ -1,6 +1,6 @@
 [download]
-key1=https://download.virtualbox.org/virtualbox/6.1.6/VirtualBox-6.1.6-137129-Win.exe
-key2=https://download.virtualbox.org/virtualbox/6.1.6/Oracle_VM_VirtualBox_Extension_Pack-6.1.6.vbox-extpack
+key1=https://download.virtualbox.org/virtualbox/7.0.10/VirtualBox-7.0.10-158379-Win.exe
+key2=https://download.virtualbox.org/virtualbox/7.0.10/Oracle_VM_VirtualBox_Extension_Pack-7.0.10.vbox-extpack
 update=http://www.vbox.me/update/
 [startvbox]
 key=0

--- a/source/Portable-VirtualBox.au3
+++ b/source/Portable-VirtualBox.au3
@@ -30,6 +30,7 @@ Opt ("TrayAutoPause", 0)
 Opt ("TrayMenuMode", 11)
 Opt ("TrayOnEventMode", 1)
 
+TraySetIcon(@ScriptDir&"\source\VirtualBox.ico")
 TraySetClick (16)
 TraySetState ()
 TraySetToolTip ("Portable-VirtualBox")
@@ -641,8 +642,8 @@ EndIf
 
       SplashOff ()
 
-      If RegRead ("HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\VBoxDRV", "DisplayName") <> "VirtualBox Service" Then
-        RunWait ("cmd /c sc create VBoxDRV binpath= ""%CD%\"& $arch &"\drivers\VBoxDrv\VBoxDrv.sys"" type= kernel start= auto error= normal displayname= PortableVBoxDRV", @ScriptDir, @SW_HIDE)
+      If RegRead ("HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\VBoxSup", "DisplayName") <> "VirtualBox Service" Then
+        RunWait ("cmd /c sc create VBoxSup binpath= ""%CD%\"& $arch &"\drivers\VBoxSup\VBoxSup.sys"" type= kernel start= auto error= normal displayname= PortableVBoxSup", @ScriptDir, @SW_HIDE)
         Local $DRV = 1
       Else
         Local $DRV = 0
@@ -711,7 +712,7 @@ EndIf
       EndIf
 
       If $DRV = 1 Then
-        RunWait ("sc start VBoxDRV", @ScriptDir, @SW_HIDE)
+        RunWait ("sc start VBoxSup", @ScriptDir, @SW_HIDE)
       EndIf
 
       If $USB = 1 Then
@@ -735,7 +736,7 @@ EndIf
           Local $UserHome = IniRead ($var1, "userhome", "key", "NotFound")
           Local $StartVM  = $CmdLine[1]
           If IniRead ($var1, "userhome", "key", "NotFound") = "%CD%\data\.VirtualBox" AND FileExists (@ScriptDir&"\data\.VirtualBox\HardDisks\"&$CmdLine[1]&".vdi") Then
-            RunWait ("cmd /c set VBOX_USER_HOME="& $UserHome &"& .\"& $arch &"\VBoxManage.exe startvm """& $StartVM &"""" , @ScriptDir, @SW_HIDE)
+            RunWait ("cmd /c set VBOX_USER_HOME="& $UserHome &"& .\"& $arch &"\VBoxSVC.exe", @ScriptDir, @SW_HIDE)
           Else
             RunWait ("cmd /c set VBOX_USER_HOME="& $UserHome &"& .\"& $arch &"\VirtualBox.exe", @ScriptDir, @SW_HIDE)
           EndIf
@@ -744,25 +745,26 @@ EndIf
         EndIf
 
         ProcessWaitClose ("VirtualBox.exe")
-        ProcessWaitClose ("VBoxManage.exe")
       Else
         If FileExists (@ScriptDir&"\data\.VirtualBox") Then
           Local $UserHome = IniRead ($var1, "userhome", "key", "NotFound")
           Local $StartVM  = IniRead ($var1, "startvm", "key", "NotFound")
           If IniRead ($var1, "startvm", "key", "NotFound") = true Then
             RunWait ("cmd /C set VBOX_USER_HOME="& $UserHome &"& .\"& $arch &"\VBoxManage.exe startvm """& $StartVM &"""" , @ScriptDir, @SW_HIDE)
+            ProcessWaitClose ("VirtualBoxVM.exe")
           Else
             RunWait ("cmd /c set VBOX_USER_HOME="& $UserHome &"& .\"& $arch &"\VirtualBox.exe", @ScriptDir, @SW_HIDE)
           EndIf
         Else
-          RunWait ("cmd /c set VBOX_USER_HOME=%CD%\data\.VirtualBox & .\"& $arch &"\VirtualBox.exe", @ScriptDir, @SW_HIDE)
+          RunWait ("cmd /c set VBOX_USER_HOME=%CD%\data\.VirtualBox & .\"& $arch &"\VirtualBox.exe", @ScriptDir, @SW_HIDE) 
         EndIf
 
         ProcessWaitClose ("VirtualBox.exe")
-        ProcessWaitClose ("VBoxManage.exe")
       EndIf
 
-      SplashTextOn ("Portable-VirtualBox", IniRead ($var2 & $lng &".ini", "messages", "07", "NotFound"), 220, 40, -1, -1, 1, "arial", 12)
+		  Local $sMessage = IniRead ($var2 & $lng &".ini", "messages", "07", "NotFound")
+		
+		  TrayTip("Portable-VirtualBox",$sMessage,10,$TIP_ICONASTERISK)
 
       ProcessWaitClose ("VBoxSVC.exe")
 
@@ -783,7 +785,7 @@ EndIf
       RunWait (@SystemDir&"\regsvr32.exe /S /U "& $arch &"\VBoxC.dll", @ScriptDir, @SW_HIDE)
 
       If $DRV = 1 Then
-        RunWait ("sc stop VBoxDRV", @ScriptDir, @SW_HIDE)
+        RunWait ("sc stop VBoxSup", @ScriptDir, @SW_HIDE)
       EndIf
 
       If $USB = 1 Then
@@ -845,7 +847,7 @@ EndIf
       EndIf
 
       If $DRV = 1 Then
-        RunWait ("sc delete VBoxDRV", @ScriptDir, @SW_HIDE)
+        RunWait ("sc delete VBoxSup", @ScriptDir, @SW_HIDE)
       EndIf
 
       If $USB = 1 Then
@@ -864,6 +866,7 @@ EndIf
         RunWait ("sc delete VBoxNetFlt", @ScriptDir, @SW_HIDE)
       EndIf
 
+      ProcessClose ("VBoxSDS.exe")
       SplashOff ()
     Else
       WinSetState ("Oracle VM VirtualBox Manager", "", BitAND (@SW_SHOW, @SW_RESTORE))


### PR DESCRIPTION
1. fixed typo in english.ini 
2. updated the download link in vboxinstall.ini to the latest version 
3. changed the exit splash screen to a notification from the tray for UI experience and fixed bug where it shows up prematurely when running portablevirtualbox with vboxmanage.exe to open up a vm on start.  this splashscreen would then stay ontop of VirtualBoxVM.exe process making using a VM unuseable